### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/index-now.yml
+++ b/.github/workflows/index-now.yml
@@ -1,5 +1,8 @@
 name: IndexNow
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "0 2 * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/ch1kulya/kappalib/security/code-scanning/1](https://github.com/ch1kulya/kappalib/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the workflow, either at the workflow root (applies to all jobs) or inside the specific job, limiting `GITHUB_TOKEN` to the least privileges needed. Since this workflow only runs a third-party action and there is no indication that it must write to the repository or interact with issues/PRs, we can restrict permissions to read-only contents at the workflow level.

The best minimal-change fix without altering behavior is to add a root-level `permissions` section right after the `name:` line, setting `contents: read`. This will ensure that, unless a job overrides it, all jobs in this workflow get a `GITHUB_TOKEN` that can only read repository contents, which should be sufficient if the action needs to fetch the repository code or metadata. No imports or additional methods are necessary, since this is a YAML configuration change only. Concretely, edit `.github/workflows/index-now.yml` to insert:

```yaml
permissions:
  contents: read
```

between the existing `name: IndexNow` and `on:` keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
