### PR TITLE
Remove views_count from sources and related triggers

### DIFF
--- a/migrations/000022_remove_source_views.down.sql
+++ b/migrations/000022_remove_source_views.down.sql
@@ -1,0 +1,23 @@
+ALTER TABLE sources ADD COLUMN views_count BIGINT NOT NULL DEFAULT 0;
+
+CREATE INDEX idx_sources_views_count ON sources (views_count DESC);
+
+CREATE OR REPLACE FUNCTION update_source_views_count()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.views_count > OLD.views_count THEN
+        UPDATE sources
+        SET views_count = views_count + (NEW.views_count - OLD.views_count)
+        WHERE id IN (
+            SELECT DISTINCT source_id
+            FROM chapters
+            WHERE novel_id = NEW.id AND source_id IS NOT NULL
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_update_source_views
+AFTER UPDATE OF views_count ON novels
+FOR EACH ROW EXECUTE FUNCTION update_source_views_count();

--- a/migrations/000022_remove_source_views.up.sql
+++ b/migrations/000022_remove_source_views.up.sql
@@ -1,0 +1,4 @@
+DROP TRIGGER IF EXISTS trg_update_source_views ON novels;
+DROP FUNCTION IF EXISTS update_source_views_count();
+DROP INDEX IF EXISTS idx_sources_views_count;
+ALTER TABLE sources DROP COLUMN IF EXISTS views_count;


### PR DESCRIPTION
Drops the views_count column from the sources table, along with its associated index, trigger, and update function. Migration files provide both up and down SQL scripts for reversible schema changes.