### PR TITLE
Fix profile login checks and add avatar timestamp

### DIFF
--- a/assets/src/modules/profile.ts
+++ b/assets/src/modules/profile.ts
@@ -49,7 +49,7 @@ class ProfileManager {
   }
 
   isLoggedIn(): boolean {
-    return this.profileId !== null;
+    return !!this.profileId;
   }
 
   getProfileId(): string | null {

--- a/internal/data/code.go
+++ b/internal/data/code.go
@@ -126,8 +126,10 @@ func LoginWithSyncCode(ctx context.Context, syncCode string) (*models.LoginRespo
 	}
 
 	var profile models.ProfilePublic
+	var avatarUpdatedAt time.Time
 	database.DB.QueryRow(dbCtx, queryUsersGet, userID).Scan(
-		&profile.ID, &profile.DisplayName, &profile.AvatarSeed, &profile.HasCustomAvatar, &profile.CreatedAt)
+		&profile.ID, &profile.DisplayName, &profile.AvatarSeed, &profile.HasCustomAvatar, &avatarUpdatedAt, &profile.CreatedAt)
+	profile.AvatarUpdatedAt = avatarUpdatedAt.Unix()
 
 	var cookies map[string]models.CookieValue
 	json.Unmarshal(cookiesJSON, &cookies)


### PR DESCRIPTION
Updated isLoggedIn in ProfileManager to use a boolean check for profileId. Modified LoginWithSyncCode in Go backend to retrieve and set AvatarUpdatedAt timestamp for profiles.