### PR TITLE
Add spoiler reveal toggle to markdown help

### DIFF
--- a/assets/src/app.ts
+++ b/assets/src/app.ts
@@ -56,6 +56,13 @@ document.addEventListener("DOMContentLoaded", () => {
       refreshLastReadTotalChapters();
     }
 
+    document.querySelector(".markdown-help")?.addEventListener("click", (e) => {
+      const target = e.target as HTMLElement;
+      if (target.classList.contains("spoiler")) {
+        target.classList.toggle("revealed");
+      }
+    });
+
     console.info("All modules initialized successfully");
   } catch (err) {
     console.error("Critical error during module initialization", err);


### PR DESCRIPTION
Adds a click event listener to elements with the 'markdown-help' class, allowing users to toggle the 'revealed' class on elements with the 'spoiler' class. This improves the user experience by enabling interactive spoiler reveals in markdown help sections.