### PR TITLE
Add 'Useful' footer links and tweak styles

### DIFF
--- a/assets/src/styles/main.css
+++ b/assets/src/styles/main.css
@@ -1253,12 +1253,15 @@ a:hover {
 .footer-section h4 {
     color: var(--tertiary);
     margin-bottom: 1rem;
+    &:not(:first-child) {
+        margin-top: 2rem;
+    }
 }
 
 .footer-nav {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.7rem;
 }
 
 .footer-disclaimer {

--- a/internal/web/views/base.templ
+++ b/internal/web/views/base.templ
@@ -119,16 +119,21 @@ templ Footer(props BaseProps) {
 	<footer class="footer">
 		<div class="footer-content">
 			<div class="footer-section">
+				<h4>Полезное</h4>
+				<nav class="footer-nav">
+					<a href="https://stats.ch1kulya.ru/q/LNdWv7KGd" target="_blank" rel="noopener noreferrer">Добавить новеллу</a>
+					<a href="https://stats.ch1kulya.ru/q/MG9BJDFXa" target="_blank" rel="noopener noreferrer">Сообщить об ошибке</a>
+				</nav>
 				<h4>Документы</h4>
 				<nav class="footer-nav">
 					<a href="/terms">Пользовательское соглашение</a>
 					<a href="/privacy">Политика конфиденциальности</a>
-					<a href="/copyright">Правообладателям</a>
-					<a href="/dmca">DMCA</a>
+					<a href="/copyright">Защита авторских прав</a>
+					<a href="/dmca">DMCA Policy</a>
 				</nav>
 			</div>
 			<div class="footer-section">
-				<h4>Информация</h4>
+				<h4>Правообладателям</h4>
 				<p class="footer-disclaimer">
 					Если материал в сервисе kappalib нарушает ваши авторские права — направьте уведомление на
 					<a href="mailto:support@kappalib.ru">support@kappalib.ru</a>


### PR DESCRIPTION
Introduce a new footer section 'Полезное' with links to add a novel and report a bug. Update footer labels ('Правообладателям' → 'Защита авторских прав', 'DMCA' → 'DMCA Policy') and change the 'Информация' heading to 'Правообладателям'. Adjust styles: add top spacing for non-first h4 elements and reduce .footer-nav gap from 0.75rem to 0.7rem. Note: the added &:not(:first-child) nesting requires a CSS preprocessor that supports nesting. !update: Добавлены полезные формы в футере