### PR TITLE
Use provider badge instead of background

### DIFF
--- a/assets/src/modules/profile.ts
+++ b/assets/src/modules/profile.ts
@@ -416,7 +416,7 @@ function getProviderSvg(provider: string | null): string {
     github:
       '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path fill="currentColor" d="M16 .396c-8.839 0-16 7.167-16 16c0 7.073 4.584 13.068 10.937 15.183c.803.151 1.093-.344 1.093-.772c0-.38-.009-1.385-.015-2.719c-4.453.964-5.391-2.151-5.391-2.151c-.729-1.844-1.781-2.339-1.781-2.339c-1.448-.989.115-.968.115-.968c1.604.109 2.448 1.645 2.448 1.645c1.427 2.448 3.744 1.74 4.661 1.328c.14-1.031.557-1.74 1.011-2.135c-3.552-.401-7.287-1.776-7.287-7.907c0-1.751.62-3.177 1.645-4.297c-.177-.401-.719-2.031.141-4.235c0 0 1.339-.427 4.4 1.641a15.4 15.4 0 0 1 4-.541c1.36.009 2.719.187 4 .541c3.043-2.068 4.381-1.641 4.381-1.641c.859 2.204.317 3.833.161 4.235c1.015 1.12 1.635 2.547 1.635 4.297c0 6.145-3.74 7.5-7.296 7.891c.556.479 1.077 1.464 1.077 2.959c0 2.14-.02 3.864-.02 4.385c0 .416.28.916 1.104.755c6.4-2.093 10.979-8.093 10.979-15.156c0-8.833-7.161-16-16-16z"></path></svg>',
     yandex:
-      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="currentColor" fill-rule="evenodd" d="M13.5 8a5.5 5.5 0 1 1-11 0a5.5 5.5 0 0 1 11 0M15 8A7 7 0 1 1 1 8a7 7 0 0 1 14 0M6.136 5.103a.75.75 0 0 0-1.272.795l2.044 3.27c.223.357.342.77.342 1.192v1.14a.75.75 0 0 0 1.5 0v-1.14a3.75 3.75 0 0 0-.57-1.987zm5 .795a.75.75 0 1 0-1.272-.795L8.77 6.853a.75.75 0 0 0 1.272.795z" clip-rule="evenodd"></path></svg>',
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><g transform="translate(8 8) scale(1.8) translate(-8 -8)"><path fill="currentColor" d="M6.136 5.103a.75.75 0 0 0-1.272.795l2.044 3.27c.223.357.342.77.342 1.192v1.14a.75.75 0 0 0 1.5 0v-1.14a3.75 3.75 0 0 0-.57-1.987zm5 .795a.75.75 0 1 0-1.272-.795L8.77 6.853a.75.75 0 0 0 1.272.795z"></path></g></svg>',
   };
   return provider ? svgs[provider] || "" : "";
 }
@@ -439,10 +439,10 @@ function renderLoggedInView(profile: ProfilePublic): void {
   );
 
   if (provider) {
-    const providerBg = content.querySelector(".pc-provider-bg");
-    if (providerBg) {
-      providerBg.setAttribute("data-provider", provider);
-      providerBg.innerHTML = getProviderSvg(provider);
+    const providerBadge = content.querySelector(".pc-provider-badge");
+    if (providerBadge) {
+      providerBadge.setAttribute("data-provider", provider);
+      providerBadge.innerHTML = getProviderSvg(provider);
     }
   }
 

--- a/assets/src/styles/main.css
+++ b/assets/src/styles/main.css
@@ -2669,26 +2669,6 @@ html {
         position: relative;
         z-index: 2;
         overflow: hidden;
-        & .pc-provider-bg {
-            position: absolute;
-            right: 1rem;
-            top: 0.75rem;
-            pointer-events: none;
-            opacity: 0.08;
-            & svg {
-                width: 65px;
-                height: 65px;
-            }
-            &[data-provider="google"] {
-                color: var(--oauth-google);
-            }
-            &[data-provider="github"] {
-                color: var(--oauth-github);
-            }
-            &[data-provider="yandex"] {
-                color: var(--oauth-yandex);
-            }
-        }
         & .pc-section {
             margin-bottom: 0;
             & .pc-desc {
@@ -2832,6 +2812,33 @@ html {
     flex-shrink: 0;
     width: 48px;
     height: 48px;
+    & .pc-provider-badge {
+        position: absolute;
+        bottom: -4px;
+        right: -4px;
+        width: 15px;
+        height: 15px;
+        border-radius: 4px;
+        background: var(--bg-primary);
+        border: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+        & svg {
+            width: 9px;
+            height: 9px;
+        }
+        &[data-provider="google"] {
+            color: var(--oauth-google);
+        }
+        &[data-provider="github"] {
+            color: var(--oauth-github);
+        }
+        &[data-provider="yandex"] {
+            color: var(--oauth-yandex);
+        }
+    }
 }
 
 .pc-avatar-wrapper .pc-avatar {

--- a/internal/web/views/profile.templ
+++ b/internal/web/views/profile.templ
@@ -94,13 +94,13 @@ templ ProfileTemplates() {
 	</template>
 	<template id="tpl-pc-profile">
 		<div class="pc-body">
-			<div class="pc-provider-bg" id="pc-provider-bg"></div>
 			<div class="pc-profile">
 				<div class="pc-avatar-wrapper">
 					<img src="" alt="" class="pc-avatar" id="pc-avatar-img" data-field="avatarUrl"/>
 					<div class="pc-avatar-overlay" id="pc-avatar-overlay">
 						<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="17 8 12 3 7 8"></polyline><line x1="12" x2="12" y1="3" y2="15"></line></svg>
 					</div>
+					<div class="pc-provider-badge" id="pc-provider-badge"></div>
 					<input type="file" id="pc-avatar-input" accept="image/jpeg,image/png" style="display:none"/>
 				</div>
 				<div class="pc-info">


### PR DESCRIPTION
Replace the large provider background with a small provider badge overlay on the avatar. Updated assets/src/modules/profile.ts to target .pc-provider-badge, added .pc-provider-badge styles in assets/src/styles/main.css (positioning, sizing, and provider color variants), and updated internal/web/views/profile.templ to remove the old .pc-provider-bg element and add .pc-provider-badge. This switches the provider SVG from a faint background element to a compact badge on the avatar for clearer UI.