### PR TITLE
Increase comment length limit to 3000

### DIFF
--- a/assets/src/modules/comments.ts
+++ b/assets/src/modules/comments.ts
@@ -409,9 +409,9 @@ function updateCharCounter(textarea: HTMLTextAreaElement): void {
   const counter = document.getElementById("comment-char-counter");
   if (counter) {
     const len = textarea.value.length;
-    counter.textContent = `${len}/1000`;
-    counter.classList.toggle("count-warning", len > 900);
-    counter.classList.toggle("count-error", len >= 1000);
+    counter.textContent = `${len}/3000`;
+    counter.classList.toggle("count-warning", len > 2500);
+    counter.classList.toggle("count-error", len >= 3000);
   }
 }
 
@@ -574,11 +574,11 @@ function renderCommentForm(container: HTMLElement): void {
           id="comment-textarea"
           class="comment-textarea"
           placeholder="Написать комментарий..."
-          maxlength="1000"
+          maxlength="3000"
           rows="2"
         ></textarea>
         <div class="comment-form-footer">
-          <span id="comment-char-counter" class="comment-char-counter">0/1000</span>
+          <span id="comment-char-counter" class="comment-char-counter">0/3000</span>
           <a href="/markdown" target="_blank" class="comment-markdown-hint">Форматирование</a>
           <div id="comments-turnstile-container"></div>
           <button id="comment-submit" class="action-btn btn-primary comment-submit-btn">Отправить</button>
@@ -937,8 +937,8 @@ function initFormHandlers(container: HTMLElement): void {
     submitBtn.addEventListener("click", async () => {
       const content = textarea.value.trim();
       if (!content) return;
-      if (content.length > 1000) {
-        alert("Комментарий слишком длинный (максимум 1000 символов)");
+      if (content.length > 3000) {
+        alert("Комментарий слишком длинный (максимум 3000 символов)");
         return;
       }
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -95,7 +95,7 @@ type GetCommentsInput struct {
 type CreateCommentInput struct {
 	ChapterID string `path:"chapterId" pattern:"^chp_[a-z0-9]{8}$"`
 	Body      struct {
-		Content        string `json:"content" minLength:"1" maxLength:"1000"`
+		Content        string `json:"content" minLength:"1" maxLength:"3000"`
 		TurnstileToken string `json:"turnstile_token" minLength:"1"`
 	}
 }
@@ -383,7 +383,7 @@ func HandleCreateComment(ctx context.Context, input *CreateCommentInput) (*Comme
 		case errors.Is(err, data.ErrCaptchaFailed):
 			return nil, huma.Error400BadRequest("Captcha verification failed")
 		case errors.Is(err, data.ErrInvalidContentLength):
-			return nil, huma.Error400BadRequest("Comment must be 1-1000 characters")
+			return nil, huma.Error400BadRequest("Comment must be 1-3000 characters")
 		case errors.Is(err, data.ErrChapterNotFound):
 			return nil, huma.Error404NotFound("Chapter not found")
 		default:
@@ -620,4 +620,3 @@ func HandleVoteComment(ctx context.Context, input *VoteCommentInput) (*VoteComme
 		}{Score: score, UserVote: input.Body.Value},
 	}, nil
 }
-

--- a/internal/data/comments.go
+++ b/internal/data/comments.go
@@ -188,7 +188,7 @@ func renderMarkdown(content string) string {
 }
 
 func CreateComment(ctx context.Context, userID string, input models.CreateCommentInput) (*models.Comment, error) {
-	if len(input.Content) == 0 || len(input.Content) > 1000 {
+	if len(input.Content) == 0 || len(input.Content) > 3000 {
 		return nil, ErrInvalidContentLength
 	}
 


### PR DESCRIPTION
Raise the allowed comment size from 1000 to 3000 characters across the codebase. Updated client UI (char counter, maxlength, warning/error thresholds, and submit validation) in assets/src/modules/comments.ts, API validation and error text in internal/api/handlers.go, and server-side data validation in internal/data/comments.go to enforce the new 3000-character limit.