### PR TITLE
Add quiet progress save and merge logic

### DIFF
--- a/assets/src/modules/profile.ts
+++ b/assets/src/modules/profile.ts
@@ -234,6 +234,14 @@ export function initProfile(): void {
   });
 }
 
+export function updateKappalibCookieQuietly(name: string, value: string): void {
+  if (!name.startsWith("kappalib_")) {
+    name = `kappalib_${name}`;
+  }
+  const encodedValue = encodeURIComponent(value);
+  document.cookie = `${name}=${encodedValue}; path=/; max-age=31536000; SameSite=Lax`;
+}
+
 export function setKappalibCookie(name: string, value: string): void {
   if (!name.startsWith("kappalib_")) {
     name = `kappalib_${name}`;

--- a/assets/src/modules/progress.ts
+++ b/assets/src/modules/progress.ts
@@ -1,4 +1,4 @@
-import { setKappalibCookie } from "./profile";
+import { setKappalibCookie, updateKappalibCookieQuietly } from "./profile";
 
 const API_URL = process.env.API_URL;
 
@@ -42,7 +42,7 @@ export function getProgressCookie(): ProgressCookie {
   return { novels: {}, lastRead: null };
 }
 
-export function saveProgressCookie(data: ProgressCookie): void {
+function trimProgressCookie(data: ProgressCookie): string {
   let json = JSON.stringify(data);
 
   while (json.length > MAX_COOKIE_SIZE && Object.keys(data.novels).length > 1) {
@@ -63,7 +63,15 @@ export function saveProgressCookie(data: ProgressCookie): void {
     json = JSON.stringify(data);
   }
 
-  setKappalibCookie(COOKIE_NAME, json);
+  return json;
+}
+
+export function saveProgressCookie(data: ProgressCookie): void {
+  setKappalibCookie(COOKIE_NAME, trimProgressCookie(data));
+}
+
+function saveProgressCookieQuietly(data: ProgressCookie): void {
+  updateKappalibCookieQuietly(COOKIE_NAME, trimProgressCookie(data));
 }
 
 export function initReadingProgressSaver(): void {
@@ -92,7 +100,7 @@ export function initReadingProgressSaver(): void {
     data.lastRead.totalChapters < totalChapters
   ) {
     data.lastRead.totalChapters = totalChapters;
-    saveProgressCookie(data);
+    saveProgressCookieQuietly(data);
   }
 
   const saveProgress = (
@@ -178,7 +186,7 @@ export async function refreshLastReadTotalChapters(): Promise<void> {
       novel.chapter_count > data.lastRead.totalChapters
     ) {
       data.lastRead.totalChapters = novel.chapter_count;
-      saveProgressCookie(data);
+      saveProgressCookieQuietly(data);
     }
   } catch {
     // ignore

--- a/internal/data/users.go
+++ b/internal/data/users.go
@@ -150,13 +150,59 @@ func validateCookies(cookies map[string]models.CookieValue) map[string]models.Co
 	return valid
 }
 
+func mergeProgressCookies(existing, incoming models.CookieValue) models.CookieValue {
+	var existingProgress, incomingProgress progressCookieSchema
+	if err := json.Unmarshal([]byte(existing.Value), &existingProgress); err != nil {
+		return incoming
+	}
+	if err := json.Unmarshal([]byte(incoming.Value), &incomingProgress); err != nil {
+		return existing
+	}
+
+	merged := progressCookieSchema{
+		Novels:   make(map[string]progressNovel),
+		LastRead: existingProgress.LastRead,
+	}
+
+	for id, novel := range existingProgress.Novels {
+		merged.Novels[id] = novel
+	}
+	for id, novel := range incomingProgress.Novels {
+		if ex, ok := merged.Novels[id]; !ok || novel.ChapterNum > ex.ChapterNum || (novel.ChapterNum == ex.ChapterNum && novel.ReadAt > ex.ReadAt) {
+			merged.Novels[id] = novel
+		}
+	}
+
+	if incomingProgress.LastRead != nil {
+		if merged.LastRead == nil || incomingProgress.LastRead.ReadAt > merged.LastRead.ReadAt {
+			merged.LastRead = incomingProgress.LastRead
+		}
+	}
+
+	if merged.LastRead != nil {
+		if novel, ok := merged.Novels[merged.LastRead.NovelID]; ok && novel.ChapterNum > merged.LastRead.ChapterNum {
+			merged.LastRead.ChapterID = novel.ChapterID
+			merged.LastRead.ChapterNum = novel.ChapterNum
+		}
+	}
+
+	data, _ := json.Marshal(merged)
+	updatedAt := existing.UpdatedAt
+	if incoming.UpdatedAt > updatedAt {
+		updatedAt = incoming.UpdatedAt
+	}
+	return models.CookieValue{Value: string(data), UpdatedAt: updatedAt}
+}
+
 func mergeCookies(existing, incoming map[string]models.CookieValue) map[string]models.CookieValue {
 	result := make(map[string]models.CookieValue)
 	maps.Copy(result, existing)
 
 	for name, incomingCv := range incoming {
 		if existingCv, exists := result[name]; exists {
-			if incomingCv.UpdatedAt > existingCv.UpdatedAt {
+			if name == "kappalib_progress" {
+				result[name] = mergeProgressCookies(existingCv, incomingCv)
+			} else if incomingCv.UpdatedAt > existingCv.UpdatedAt {
 				result[name] = incomingCv
 			}
 		} else {


### PR DESCRIPTION
Introduce a quiet cookie updater and refactor progress cookie saving to trim large payloads before writing. profile.ts: add updateKappalibCookieQuietly for silent cookie updates. progress.ts: extract trimProgressCookie, add saveProgressCookieQuietly that uses the quiet updater, and switch autosave/refresh paths to use the quiet saver; keep public saveProgressCookie behavior unchanged. internal/data/users.go: add mergeProgressCookies to intelligently merge kappalib_progress values (merge novel entries preferring higher chapter or newer readAt, reconcile lastRead, and pick the latest UpdatedAt) and wire it into mergeCookies so kappalib_progress is merged instead of blindly chosen by timestamp.