### PR TITLE
Make comments focusable and hide delete button

### DIFF
--- a/assets/src/modules/comments.ts
+++ b/assets/src/modules/comments.ts
@@ -219,7 +219,7 @@ function createCommentHTML(comment: Comment): string {
   }
 
   return `
-    <div class="comment-item${extraClass}" data-comment-id="${comment.id}" data-comment-status="${comment.status}">
+    <div class="comment-item${extraClass}" data-comment-id="${comment.id}" data-comment-status="${comment.status}" tabindex="0">
       <div class="comment-header">
         <img src="${avatarUrl}" alt="${comment.user_display_name}" class="comment-avatar" loading="lazy"/>
         <span class="comment-author">${comment.user_display_name} ${statusBadge}</span>
@@ -269,7 +269,7 @@ function createAnswerHTML(answer: CommentAnswer): string {
   }
 
   return `
-    <div class="comment-answer${extraClass}" data-answer-id="${answer.id}">
+    <div class="comment-answer${extraClass}" data-answer-id="${answer.id}" tabindex="0">
       <div class="comment-header">
         <img src="${avatarUrl}" alt="${answer.user_display_name}" class="comment-answer-avatar" loading="lazy"/>
         <span class="comment-author">${answer.user_display_name} ${statusBadge}</span>

--- a/assets/src/styles/main.css
+++ b/assets/src/styles/main.css
@@ -4026,10 +4026,22 @@ html {
     cursor: pointer;
     padding: 0;
     transition:
-        color 0.15s,
-        background 0.15s;
+        color 0.1s,
+        background 0.1s,
+        opacity 0.1s,
+        visibility 0.1s;
     position: relative;
     bottom: -0.05rem;
+    opacity: 0;
+    visibility: hidden;
+}
+
+.comment-item:hover > .comment-header .comment-delete-btn,
+.comment-item:hover > .comment-body .comment-delete-btn,
+.comment-answer:hover > .comment-header .comment-delete-btn,
+.comment-answer:hover > .comment-body .comment-delete-btn {
+    opacity: 1;
+    visibility: visible;
 }
 
 @media (hover: hover) {
@@ -4040,6 +4052,8 @@ html {
 
 .comment-delete-btn:active {
     color: var(--color-danger);
+    opacity: 1;
+    visibility: visible;
 }
 
 @media (max-width: 500px) {


### PR DESCRIPTION
Add keyboard focusability to comment and answer containers by adding tabindex="0" to their root elements. Update delete-button styles to hide it by default (opacity/visibility) and reveal it on hover or when active; also adjust transition properties and durations for color, background, opacity and visibility to make the reveal smoother. These changes improve accessibility and reduce visual clutter until the user interacts with a comment.