### PR TITLE
Add theme CSS fallbacks and color schemes

### DIFF
--- a/assets/src/styles/theme.css
+++ b/assets/src/styles/theme.css
@@ -264,3 +264,141 @@
 :root[data-theme="dark"] {
     color-scheme: dark;
 }
+
+@supports not (light-dark: red blue) {
+    :root,
+    :root[data-scheme="default"] {
+        --bg-primary: #f9f9f9;
+        --primary: #1b1b1b;
+        --secondary: #757575;
+        --tertiary: #8e8e8e;
+        --border: #d5d4d5;
+        --outline: #f1f1f1;
+        --shadow-primary: inset 0 0 0 1px rgba(0, 0, 0, 0.04), 0 1px 0 rgba(0, 0, 0, 0.03);
+        --shadow-secondary: inset 0 0 0 1px rgba(0, 0, 0, 0.02), 0 0.5px 0 rgba(0, 0, 0, 0.02);
+        --shadow-focus: inset 0 0 0 1px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(0, 0, 0, 0.04), 0 1px 0 rgba(0, 0, 0, 0.03);
+        --shadow-inverted-primary: inset 0 0 0 1px rgba(255, 255, 255, 0.24), 0 1px 0 rgba(0, 0, 0, 0.31);
+        --shadow-inverted-focus: inset 0 0 0 1px rgba(255, 255, 255, 0.31), 0 0 0 1px rgba(255, 255, 255, 0.2), 0 1px 0 rgba(0, 0, 0, 0.25);
+    }
+
+    :root[data-theme="dark"],
+    @media (prefers-color-scheme: dark) {
+        :root {
+            --bg-primary: #131313;
+            --primary: #e7e7e7;
+            --secondary: #a5a5a5;
+            --tertiary: #7b7b7b;
+            --border: #2a2b2a;
+            --outline: #272727;
+            --shadow-primary: inset 0 0 0 1px rgba(255, 255, 255, 0.06), 0 1px 0 rgba(0, 0, 0, 0.15);
+            --shadow-secondary: inset 0 0 0 1px rgba(255, 255, 255, 0.03), 0 0.5px 0 rgba(0, 0, 0, 0.08);
+            --shadow-focus: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 0 0 1px rgba(255, 255, 255, 0.06), 0 1px 0 rgba(0, 0, 0, 0.12);
+            --shadow-inverted-primary: inset 0 0 0 1px rgba(255, 255, 255, 0.24), 0 1px 0 rgba(0, 0, 0, 0.31);
+            --shadow-inverted-focus: inset 0 0 0 1px rgba(255, 255, 255, 0.31), 0 0 0 1px rgba(255, 255, 255, 0.2), 0 1px 0 rgba(0, 0, 0, 0.25);
+        }
+    }
+
+    :root[data-scheme="catppuccin"] {
+        --bg-primary: #eff1f5;
+        --primary: #4c4f69;
+        --secondary: #6c6f85;
+        --tertiary: #8c8fa1;
+        --border: #ccd0da;
+        --outline: #e6e9ef;
+        --shadow-primary: inset 0 0 0 1px rgba(0, 0, 0, 0.04), 0 1px 0 rgba(0, 0, 0, 0.03);
+        --shadow-secondary: inset 0 0 0 1px rgba(0, 0, 0, 0.02), 0 0.5px 0 rgba(0, 0, 0, 0.02);
+        --shadow-focus: inset 0 0 0 1px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(0, 0, 0, 0.04), 0 1px 0 rgba(0, 0, 0, 0.03);
+    }
+
+    @media (prefers-color-scheme: dark) {
+        :root[data-scheme="catppuccin"] {
+            --bg-primary: #1e1e2e;
+            --primary: #cdd6f4;
+            --secondary: #a6adc8;
+            --tertiary: #7f849c;
+            --border: #313244;
+            --outline: #262637;
+            --shadow-primary: inset 0 0 0 1px rgba(255, 255, 255, 0.06), 0 1px 0 rgba(0, 0, 0, 0.15);
+            --shadow-secondary: inset 0 0 0 1px rgba(255, 255, 255, 0.03), 0 0.5px 0 rgba(0, 0, 0, 0.08);
+            --shadow-focus: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 0 0 1px rgba(255, 255, 255, 0.06), 0 1px 0 rgba(0, 0, 0, 0.12);
+        }
+    }
+
+    :root[data-scheme="gruvbox"] {
+        --bg-primary: #fbf1c7;
+        --primary: #3c3836;
+        --secondary: #665c54;
+        --tertiary: #7c6f64;
+        --border: #d5c4a1;
+        --outline: #ebdbb2;
+        --shadow-primary: inset 0 0 0 1px rgba(0, 0, 0, 0.04), 0 1px 0 rgba(0, 0, 0, 0.03);
+        --shadow-secondary: inset 0 0 0 1px rgba(0, 0, 0, 0.02), 0 0.5px 0 rgba(0, 0, 0, 0.02);
+        --shadow-focus: inset 0 0 0 1px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(0, 0, 0, 0.04), 0 1px 0 rgba(0, 0, 0, 0.03);
+    }
+
+    @media (prefers-color-scheme: dark) {
+        :root[data-scheme="gruvbox"] {
+            --bg-primary: #282828;
+            --primary: #ebdbb2;
+            --secondary: #a89984;
+            --tertiary: #928374;
+            --border: #3c3836;
+            --outline: #32302f;
+            --shadow-primary: inset 0 0 0 1px rgba(255, 255, 255, 0.06), 0 1px 0 rgba(0, 0, 0, 0.15);
+            --shadow-secondary: inset 0 0 0 1px rgba(255, 255, 255, 0.03), 0 0.5px 0 rgba(0, 0, 0, 0.08);
+            --shadow-focus: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 0 0 1px rgba(255, 255, 255, 0.06), 0 1px 0 rgba(0, 0, 0, 0.12);
+        }
+    }
+
+    :root[data-scheme="nord"] {
+        --bg-primary: #eceff4;
+        --primary: #2e3440;
+        --secondary: #4c566a;
+        --tertiary: #616e88;
+        --border: #d8dee9;
+        --outline: #e5e9f0;
+        --shadow-primary: inset 0 0 0 1px rgba(0, 0, 0, 0.04), 0 1px 0 rgba(0, 0, 0, 0.03);
+        --shadow-secondary: inset 0 0 0 1px rgba(0, 0, 0, 0.02), 0 0.5px 0 rgba(0, 0, 0, 0.02);
+        --shadow-focus: inset 0 0 0 1px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(0, 0, 0, 0.04), 0 1px 0 rgba(0, 0, 0, 0.03);
+    }
+
+    @media (prefers-color-scheme: dark) {
+        :root[data-scheme="nord"] {
+            --bg-primary: #2e3440;
+            --primary: #eceff4;
+            --secondary: #d8dee9;
+            --tertiary: #81a1c1;
+            --border: #3b4252;
+            --outline: #3a3f4b;
+            --shadow-primary: inset 0 0 0 1px rgba(255, 255, 255, 0.06), 0 1px 0 rgba(0, 0, 0, 0.15);
+            --shadow-secondary: inset 0 0 0 1px rgba(255, 255, 255, 0.03), 0 0.5px 0 rgba(0, 0, 0, 0.08);
+            --shadow-focus: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 0 0 1px rgba(255, 255, 255, 0.06), 0 1px 0 rgba(0, 0, 0, 0.12);
+        }
+    }
+
+    :root[data-scheme="rosepine"] {
+        --bg-primary: #faf4ed;
+        --primary: #575279;
+        --secondary: #797593;
+        --tertiary: #9893a5;
+        --border: #dfdad9;
+        --outline: #f2e9e1;
+        --shadow-primary: inset 0 0 0 1px rgba(0, 0, 0, 0.04), 0 1px 0 rgba(0, 0, 0, 0.03);
+        --shadow-secondary: inset 0 0 0 1px rgba(0, 0, 0, 0.02), 0 0.5px 0 rgba(0, 0, 0, 0.02);
+        --shadow-focus: inset 0 0 0 1px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(0, 0, 0, 0.04), 0 1px 0 rgba(0, 0, 0, 0.03);
+    }
+
+    @media (prefers-color-scheme: dark) {
+        :root[data-scheme="rosepine"] {
+            --bg-primary: #232136;
+            --primary: #e0def4;
+            --secondary: #908caa;
+            --tertiary: #6e6a86;
+            --border: #393552;
+            --outline: #2a283e;
+            --shadow-primary: inset 0 0 0 1px rgba(255, 255, 255, 0.06), 0 1px 0 rgba(0, 0, 0, 0.15);
+            --shadow-secondary: inset 0 0 0 1px rgba(255, 255, 255, 0.03), 0 0.5px 0 rgba(0, 0, 0, 0.08);
+            --shadow-focus: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 0 0 1px rgba(255, 255, 255, 0.06), 0 1px 0 rgba(0, 0, 0, 0.12);
+        }
+    }
+}


### PR DESCRIPTION
Introduce an `@supports` fallback block to provide CSS custom properties for users/browsers that don't support the light-dark feature. Define default light/dark variables and add themed variable sets for catppuccin, gruvbox, nord, and rosepine, including `prefers-color-scheme: dark` overrides and shadow/border/outline tokens to ensure consistent theming across light and dark modes. !update: Исправлена проблема со стилями в старых браузерах