### PR TITLE
Set esbuild engine to Chrome 100

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -78,6 +78,9 @@ func buildAssets() error {
 			"process.env.S3_PUBLIC_URL":               fmt.Sprintf("\"%s\"", os.Getenv("S3_PUBLIC_URL")),
 		},
 		External: []string{"/assets/fonts/*"},
+		Engines: []esbuild.Engine{
+			{Name: esbuild.EngineChrome, Version: "100"},
+		},
 	})
 
 	if len(result.Errors) > 0 {


### PR DESCRIPTION
Add an Engines entry to the esbuild options in cmd/server/main.go (buildAssets) to specify Chrome 100 as the target engine. This makes the bundler use the Chrome 100 engine version when building assets, influencing output compatibility and polyfill handling.