### PR TITLE
Add keyboard navigation for chapter nav

### DIFF
--- a/assets/src/modules/progress.ts
+++ b/assets/src/modules/progress.ts
@@ -170,6 +170,26 @@ export function initReadingProgressSaver(): void {
   window.addEventListener("beforeunload", () => {
     clearTimeout(timerId);
   });
+
+  setupKeyboardNavigation();
+}
+
+function setupKeyboardNavigation(): void {
+  const nav = document.querySelector<HTMLElement>(".chapter-navigation");
+  if (!nav) return;
+
+  document.addEventListener("keydown", (e: KeyboardEvent) => {
+    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+
+    const prevLink = nav.querySelector<HTMLAnchorElement>("a:not(.js-next-chapter)");
+    const nextLink = nav.querySelector<HTMLAnchorElement>("a.js-next-chapter");
+
+    if (e.key === "ArrowLeft" && prevLink) {
+      prevLink.click();
+    } else if (e.key === "ArrowRight" && nextLink) {
+      nextLink.click();
+    }
+  });
 }
 
 export async function refreshLastReadTotalChapters(): Promise<void> {


### PR DESCRIPTION
Introduce setupKeyboardNavigation() and call it from initReadingProgressSaver. The new keydown handler listens for ArrowLeft/ArrowRight and triggers the previous/next chapter links inside .chapter-navigation (selecting a:not(.js-next-chapter) for prev and a.js-next-chapter for next). It skips handling when focus is inside input or textarea elements to avoid interfering with typing.

!update: Добавлено перемещение между главами с помощью кнопок ArrowLeft и ArrowRight